### PR TITLE
Added support for Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "gitane": "~0.3.1",
     "shell-escape": "0.0.1",
-    "mkdirp": "~0.3.5"
+    "fs-extra": "~0.8.1"
   },
   "devDependencies": {
     "jshint": "~2.3.0",

--- a/worker.js
+++ b/worker.js
@@ -1,8 +1,7 @@
 
 var path = require('path')
-  , fs = require('fs')
+  , fs = require('fs-extra')
   , spawn = require('child_process').spawn
-  , mkdirp = require('mkdirp')
 
   , utils = require('./lib')
 
@@ -122,7 +121,7 @@ function fetch(dest, config, job, context, done) {
     , cloning = false
     , pleaseClone = function () {
         cloning = true
-        mkdirp(dest, function () {
+        fs.mkdirp(dest, function () {
           clone(dest, config, job.ref, context, updateCache)
         })
       }
@@ -136,7 +135,7 @@ function fetch(dest, config, job, context, done) {
         context.comment('restored code from cache')
         return pull(dest, config, context, updateCache)
       }
-      safespawn('rm', ['-rf', dest]).on('close', function (exitCode) {
+      fs.remove(dest, function(err) {
         pleaseClone()
       })
     })


### PR DESCRIPTION
Calling `rm -rf` in Windows will not work. I replaced this call with fs-extra's `remove` method. I also replaced the `mkdirp` calls to fs-extra's version (so there is no need to have both packages as dependencies). Should help with https://github.com/Strider-CD/strider/issues/326
