### PR TITLE
Run Gitane commands through context spawn function.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -95,6 +95,7 @@ function gitaneCmd(cmd, dest, privkey, context, done) {
       emit: context.status
     },
     cmd: cmd,
+    spawn: context.runCmd,
     baseDir: dest,
     privKey: privkey,
     detached: true


### PR DESCRIPTION
With https://github.com/niallo/Gitane/pull/4, `gitane` can now accept a custom spawn function.
This should be set to `context.runCmd` for compatibility with various Strider workflows which involve not directly running the process on the CI/CD machine. An example of this is current breakage under [strider-docker-runner](https://github.com/Strider-CD/strider-docker-runner), where a git `clone`/`checkout` combination fails to work.